### PR TITLE
Remove issue entity from tests

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -555,7 +555,8 @@
     }, 100),
     '.closed click': function (el, ev) {
       var $link = el.closest('a');
-      var widget = this.widget_by_selector($link.attr('href'));
+      var widget = this.widget_by_selector('#' + $link.attr('href')
+                                                      .split('#')[1]);
       var widgets = this.options.widget_list;
 
       widget.attr('force_show', false);

--- a/src/ggrc/assets/mustache/components/assessment/attachments-list.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/attachments-list.mustache
@@ -6,6 +6,7 @@
 <h6>Evidence</h6>
   {{#is_allowed 'update' instance context='for'}}
     {{{render_hooks "Request.gdrive_evidence_storage"}}}
+    <div class="attach-file-info">(you can upload up to 10 files in a single batch)</div>
   {{/is_allowed}}
 {{^if_null instance._mandatory_attachment_msg}}
   <div class="alert alert-info alert-dismissible" role="alert">

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -62,6 +62,12 @@ $border-color: #eee;
       flex: 1 1 50%;
       max-width: 50%;
     }
+
+    .attach-file-info {
+      margin: -10px 0 10px;
+      font-size: 0.9em;
+      font-style: italic;
+    }
   }
 }
 

--- a/test/selenium/src/tests/test_object_mapping.py
+++ b/test/selenium/src/tests/test_object_mapping.py
@@ -7,13 +7,13 @@
 # pylint: disable=too-few-public-methods
 # pylint: disable=unused-argument
 
-import pytest    # pylint: disable=import-error
+import pytest
 
 from lib import base
 from lib import factory
+from lib.page import dashboard
 from lib.utils import conftest_utils
 from lib.utils import selenium_utils
-from lib.page import dashboard
 
 
 class TestObjectMapping(base.Test):
@@ -22,10 +22,10 @@ class TestObjectMapping(base.Test):
   @pytest.mark.smoke_tests
   def test_mapping_via_lhn(self, selenium, new_product,
                            new_project, new_system, new_data_asset,
-                           new_process, new_issue):
+                           new_process):
     """LHN mapping tests from smoke tests, section 6"""
     objects = [new_product, new_project, new_system, new_data_asset,
-               new_process, new_issue]
+               new_process]
 
     for object_ in objects:
       selenium.get(object_.url)


### PR DESCRIPTION
Currently issue can be mapped for audit only, so this PR removes issue entity from common mapping tests to other entities.